### PR TITLE
Fixed bugg where board freezes on checkmate.

### DIFF
--- a/src/components/chessboard/index.vue
+++ b/src/components/chessboard/index.vue
@@ -117,7 +117,7 @@ export default {
       if (this.showThreats) {
         this.paintThreats()
       }
-      let threats = this.countThreats(this.toColor())
+      let threats = this.countThreats(this.toColor()) || {}
       threats['history'] = this.game.history()
       threats['fen'] = this.game.fen()
       this.$emit('onMove', threats)


### PR DESCRIPTION
countThreats returns null when no legal moves are found. afterMove chrashes when trying to use a-"history" property from the return of countThreats. Defaults to empty object in afterMove.